### PR TITLE
extending the list of stop signals

### DIFF
--- a/gracy.go
+++ b/gracy.go
@@ -12,7 +12,7 @@ import (
 
 const defaultTimeout = 10 * time.Second
 
-var defaultSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT}
+var defaultSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP, syscall.SIGKILL}
 
 type CallbackFunc func() error
 


### PR DESCRIPTION
Hi.

Added aditional stop signals syscall.SIGKILL and syscall.SIGHUP.
The syscall.SIGKILL in most cases is not processed by the golang, but sometimes it may be processed and you can show the correct error message.